### PR TITLE
feat: Add expansion-based filter to ProfitFrame and update all locales

### DIFF
--- a/Locale/deDE.lua
+++ b/Locale/deDE.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/esES.lua
+++ b/Locale/esES.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/esMX.lua
+++ b/Locale/esMX.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/frFR.lua
+++ b/Locale/frFR.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/koKR.lua
+++ b/Locale/koKR.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/ptBR.lua
+++ b/Locale/ptBR.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Show item in tip instead of spell";
 l10n["showRankTip"] = "Show colored difficulty rank";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Show cost only";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Current Expac Only";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Get from: |r";
 l10n["quest"] = "Quest";

--- a/Locale/ruRU.lua
+++ b/Locale/ruRU.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "Показывать предмет в по
 l10n["showRankTip"] = "Показывать цветной ранг сложности";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "Показывать только стоимость";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "Только текущее дополнение";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00Получено из: |r";
 l10n["quest"] = "Задание";

--- a/Locale/zhCN.lua
+++ b/Locale/zhCN.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "鼠标提示显示物品而不是技能";
 l10n["showRankTip"] = "显示难度等级";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "只显示成本";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "仅当前版本";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00来源: |r";
 l10n["quest"] = "任务";

--- a/Locale/zhTW.lua
+++ b/Locale/zhTW.lua
@@ -135,6 +135,7 @@ l10n["showItemInsteadOfSpellTip"] = "鼠標提示顯示物品而不是技能";
 l10n["showRankTip"] = "顯示難度等級";
 --
 l10n["PROFIT_SHOW_COST_ONLY"] = "只顯示成本";
+l10n["PROFIT_SHOW_CUR_EXPAC_ONLY"] = "僅當前版本";
 --
 l10n["LABEL_GET_FROM"] = "|cffff7f00來源: |r";
 l10n["quest"] = "任務";

--- a/setting.lua
+++ b/setting.lua
@@ -133,6 +133,7 @@ MT.BuildEnv("setting");
 		searchNameOnly = false,
 		--
 		PROFIT_SHOW_COST_ONLY = false,
+		PROFIT_SHOW_CUR_EXPAC_ONLY = true,
 		--
 	};
 	local default_var = {


### PR DESCRIPTION
- Implement 'Only Current Version' checkbox in ProfitFrame
- Add adaptive skill threshold logic for multi-version support
- Update default settings to enable the filter by default
- Add localization strings for all supported languages